### PR TITLE
Fix entrypoint registration for callable functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.1] - 2022-09-02
+## [0.2.0] - 2022-09-02
+### Added
+ - When registering commands, you can pass extra arguments to the typer's `app.command` method, by setting
+   CLI entry point function attribute `typer_kwargs` to the corresponding kwargs dict.
+   ([#4](https://github.com/pyodide/pyodide-cli/pull/2))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2022-09-02
+
+### Changed
+
+ - Fix entry point registration for callable functions ([#4](https://github.com/pyodide/pyodide-cli/pull/2))
+
+## [0.1.0] - 2022-09-02
+
+Initial release

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -35,9 +35,11 @@ def register_plugins():
         if isinstance(module, typer.Typer):
             app.add_typer(module, name=plugin_name)
         elif callable(module):
-            app.command(
-                plugin_name,
-            )(module)
+            context_settings = getattr(module, "typer_context_settings", {})
+            kwargs = {}
+            if context_settings:
+                kwargs = {"context_settings": context_settings}
+            app.command(plugin_name, **kwargs)(module)
         else:
             raise RuntimeError(f"Invalid plugin: {plugin_name}")
 

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -28,23 +28,6 @@ def callback(
     pass
 
 
-def _register_callable(func, name):
-    @app.command(
-        name,
-        help=func.__doc__,
-        context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
-    )
-    def _cmd(
-        help: bool = typer.Option(False),
-        ctx: typer.Context = typer.Context,
-    ):
-        if help:
-            typer.echo(ctx.get_help())
-            raise typer.Exit()
-        else:
-            func(*ctx.args)
-
-
 def register_plugins():
     eps = entry_points(group="pyodide.cli")
     plugins = {ep.name: ep.load() for ep in eps}
@@ -52,7 +35,9 @@ def register_plugins():
         if isinstance(module, typer.Typer):
             app.add_typer(module, name=plugin_name)
         elif callable(module):
-            _register_callable(module, plugin_name)
+            app.command(
+                plugin_name,
+            )(module)
         else:
             raise RuntimeError(f"Invalid plugin: {plugin_name}")
 

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -35,11 +35,8 @@ def register_plugins():
         if isinstance(module, typer.Typer):
             app.add_typer(module, name=plugin_name)
         elif callable(module):
-            context_settings = getattr(module, "typer_context_settings", {})
-            kwargs = {}
-            if context_settings:
-                kwargs = {"context_settings": context_settings}
-            app.command(plugin_name, **kwargs)(module)
+            typer_kwargs = getattr(module, "typer_kwargs", {})
+            app.command(plugin_name, **typer_kwargs)(module)
         else:
             raise RuntimeError(f"Invalid plugin: {plugin_name}")
 


### PR DESCRIPTION
While working on https://github.com/pyodide/pyodide-pack/pull/8 I wasn't able to make `pyodide pack --help` work with the current version of the codebase. 

I think this extra wrapper is not necessary, typer already does the right thing. About `context_settings` for command it is now passed via a custom attribute on the CLI entrypoint function, as we don't want `allow_extra_args` and `ignore_unknown_options` enabled everwhere.

cc @ryanking13 