### PR TITLE
Document how to registed pyodide CLI subcommands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pytest
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     environment: PyPi-deploy
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,5 @@ repos:
     hooks:
       - id: codespell
         args: ["-L", "te,slowy,aray,ba,nd,classs,crate,feld,lits"]
+ci:
+  autoupdate_schedule: "quarterly"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can register a subcommand in the `pyodide` CLI in your own package by:
    ```toml
    [options.entry_points]
    pyodide.cli =
-    do_something = <your-package>.cli:main
+    do_something = "<your-package>.cli:main"
    ```
 
    or

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can register a subcommand in the `pyodide` CLI in your own package by:
    ```toml
    [options.entry_points]
    pyodide.cli =
-    <subcommand-name> = <your-package>.cli:main
+    do_something = <your-package>.cli:main
    ```
 
    or
@@ -41,7 +41,7 @@ You can register a subcommand in the `pyodide` CLI in your own package by:
    **pyproject.toml**
    ```toml
    [project.entry-points."pyodide.cli"]
-   <subcommand-name> = "<your-package>.cli:main"
+   do_something = "<your-package>.cli:main"
    ```
 
    where in this example `main` needs to be a function with type annotations

--- a/README.md
+++ b/README.md
@@ -22,6 +22,32 @@ To get a list of available CLI commands,
 pyodide --help
 ```
 
+## Developers
+
+You can register a subcommand in the `pyodide` CLI in your own package by:
+
+1. adding a dependency on `pyodide-cli`
+2. Adding a `pyodide.cli` [entry point](https://setuptools.pypa.io/en/latest/userguide/entry_point.html). For example, with
+
+   **setup.cfg**
+   ```toml
+   [options.entry_points]
+   pyodide.cli =
+    <subcommand-name> = <your-package>.cli:main
+   ```
+
+   or
+
+   **pyproject.toml**
+   ```toml
+   [project.entry-points."pyodide.cli"]
+   <subcommand-name> = "<your-package>.cli:main"
+   ```
+
+   where in this example `main` needs to be a function with type annotations
+   that can be converted to a CLI with [typer](https://typer.tiangolo.com/).
+
+
 ## License
 
 pyodide-cli uses the [Mozilla Public License Version


### PR DESCRIPTION
This,
 - documents how to register CLI subcommand in third-party packages
 - in pre-commit.ci switches from weekly auto-update to quarterly auto-update to reduce of the amount of pre-commit.ci PR.