### PR TITLE
Show origin of subcommands in help message

### DIFF
--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -32,7 +32,7 @@ def callback(
     pass
 
 
-def entrypoint_to_pkgname(entrypoint: EntryPoint) -> str:
+def _entrypoint_to_pkgname(entrypoint: EntryPoint) -> str:
     """Find package name from entrypoint"""
 
     top_level = entrypoint.value.split(".")[0]
@@ -49,7 +49,7 @@ def register_plugins():
     eps = entry_points(group="pyodide.cli")
     plugins = {ep.name: (ep.load(), ep) for ep in eps}
     for plugin_name, (module, ep) in plugins.items():
-        pkgname = entrypoint_to_pkgname(ep)
+        pkgname = _entrypoint_to_pkgname(ep)
         origin_text = f"Registered by: {pkgname}"
 
         if isinstance(module, typer.Typer):

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -41,7 +41,7 @@ def _entrypoint_to_pkgname(entrypoint: EntryPoint) -> str:
 
 
 def _inject_origin(docstring: str, origin: str) -> str:
-    return f"{docstring}\n\n * {origin}"
+    return f"{docstring}\n\n{origin}"
 
 
 def register_plugins():

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -4,10 +4,11 @@ from importlib.metadata import distribution as importlib_distribution
 from importlib.metadata import entry_points
 
 import typer  # type: ignore[import]
+from typer.main import TyperInfo, solve_typer_info_help  # type: ignore[import]
 
 from . import __version__
 
-app = typer.Typer(add_completion=False)
+app = typer.Typer(add_completion=False, rich_markup_mode="markdown")
 
 
 def version_callback(value: bool):
@@ -39,20 +40,37 @@ def entrypoint_to_pkgname(entrypoint: EntryPoint) -> str:
     return dist.metadata["name"]
 
 
+def _inject_origin(docstring: str, origin: str) -> str:
+    return f"{docstring}\n\n * {origin}"
+
+
 def register_plugins():
     """Register subcommands via the ``pyodide.cli`` entry-point"""
     eps = entry_points(group="pyodide.cli")
     plugins = {ep.name: (ep.load(), ep) for ep in eps}
     for plugin_name, (module, ep) in plugins.items():
         pkgname = entrypoint_to_pkgname(ep)
+        origin_text = f"Registered by: {pkgname}"
+
         if isinstance(module, typer.Typer):
+            typer_info = TyperInfo(module)
+            help_with_origin = _inject_origin(
+                solve_typer_info_help(typer_info), origin_text
+            )
             app.add_typer(
-                module, name=plugin_name, rich_help_panel=f"Registered by: {pkgname}"
+                module,
+                name=plugin_name,
+                rich_help_panel=origin_text,
+                help=help_with_origin,
             )
         elif callable(module):
             typer_kwargs = getattr(module, "typer_kwargs", {})
+            help_with_origin = _inject_origin(module.__doc__, origin_text)
             app.command(
-                plugin_name, rich_help_panel=f"Registered by: {pkgname}", **typer_kwargs
+                plugin_name,
+                rich_help_panel=origin_text,
+                help=help_with_origin,
+                **typer_kwargs,
             )(module)
         else:
             raise RuntimeError(f"Invalid plugin: {plugin_name}")

--- a/pyodide_cli/tests/plugin-test/plugin_test/app.py
+++ b/pyodide_cli/tests/plugin-test/plugin_test/app.py
@@ -1,0 +1,24 @@
+import typer  # type: ignore[import]
+
+app = typer.Typer()
+
+
+@app.callback()
+def callback():
+    """
+    Test help message short desc
+
+    Test help message long desc
+    """
+    pass
+
+
+@app.command()
+def hello(name: str = typer.Argument(..., help="Test argument")):
+    """
+    Test help message short desc
+
+    Test help message long desc
+    """
+    typer.echo(f"Hello {name}")
+    pass

--- a/pyodide_cli/tests/plugin-test/plugin_test/main.py
+++ b/pyodide_cli/tests/plugin-test/plugin_test/main.py
@@ -1,2 +1,7 @@
 def main():
+    """
+    Test help message short desc
+
+    Test help message long desc
+    """
     pass

--- a/pyodide_cli/tests/plugin-test/pyproject.toml
+++ b/pyodide_cli/tests/plugin-test/pyproject.toml
@@ -8,4 +8,5 @@ version = "1.0.0"
 authors = []
 
 [project.entry-points."pyodide.cli"]
-plugin_test = "plugin_test.main:main"
+plugin_test_func = "plugin_test.main:main"
+plugin_test_app = "plugin_test.app:app"

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -57,3 +57,12 @@ def test_plugin_origin(plugins):
     msg = "Registered by: plugin-test"
 
     assert msg in output
+
+
+@pytest.mark.parametrize("entrypoint", ["plugin_test_app", "plugin_test_func"])
+def test_plugin_origin_subcommand(plugins, entrypoint):
+
+    output = check_output(["pyodide", entrypoint, "--help"]).decode("utf-8")
+    msg = "Registered by: plugin-test"
+
+    assert msg in output


### PR DESCRIPTION
Close: #18 

This appends "Registered-by: <pkgname>" at the bottom of the help message of each subcommand.

In terminal it is displayed like this:

![image](https://user-images.githubusercontent.com/24893111/208851059-e11d413a-a73d-4e91-975d-c9fd76e1e7d1.png)

I'm not sure how it will be rendered in docs though (will it parse markdown...?)


