### PR TITLE
Show versions of registered plugins

### DIFF
--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -1,6 +1,6 @@
-from functools import cache
 import sys
-from importlib.metadata import EntryPoint, Distribution
+from functools import cache
+from importlib.metadata import Distribution, EntryPoint
 from importlib.metadata import distribution as importlib_distribution
 from importlib.metadata import entry_points
 
@@ -19,17 +19,14 @@ app = typer.Typer(
 def version_callback(value: bool):
     if not value:
         return
-        
-    typer.echo(f"Pyodide CLI Version: {__version__}")
+
+    typer.echo(f"pyodide CLI version: {__version__}")
 
     eps = entry_points(group="pyodide.cli")
     # filter out duplicate pkgs
-    pkgs = {
-        _entrypoint_to_pkgname(ep): _entrypoint_to_version(ep)
-        for ep in eps
-    }
+    pkgs = {_entrypoint_to_pkgname(ep): _entrypoint_to_version(ep) for ep in eps}
     for pkg, version in pkgs.items():
-        typer.echo(f"{pkg} Version: {version}")
+        typer.echo(f"{pkg} version: {version}")
 
     raise typer.Exit()
 
@@ -38,7 +35,11 @@ def version_callback(value: bool):
 def callback(
     ctx: typer.Context,
     version: bool = typer.Option(
-        None, "--version", callback=version_callback, is_eager=True, help="Show the version of the Pyodide CLI",
+        None,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show the version of the Pyodide CLI",
     ),
 ):
     """A command line interface for Pyodide.
@@ -51,7 +52,7 @@ def callback(
 
 @cache
 def _entrypoint_to_distribution(entrypoint: EntryPoint) -> Distribution:
-    """Find package ditribution from entrypoint"""
+    """Find package distribution from entrypoint"""
     top_level = entrypoint.value.split(".")[0]
     dist = importlib_distribution(top_level)
     return dist

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -19,8 +19,12 @@ def plugins():
 
 def test_cli_help():
     output = check_output(["pyodide", "--help"]).decode("utf-8")
-    msg = "A command line interface for Pyodide."
-    assert msg in output
+    assert "A command line interface for Pyodide." in output
+
+def test_cli_version():
+    output = check_output(["pyodide", "--version"]).decode("utf-8")
+    assert "Pyodide CLI Version:" in output
+    assert "plugin-test Version: 1.0.0" in output
 
 
 def test_click_click_object_defintion():

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -21,10 +21,11 @@ def test_cli_help():
     output = check_output(["pyodide", "--help"]).decode("utf-8")
     assert "A command line interface for Pyodide." in output
 
-def test_cli_version():
+
+def test_cli_version(plugins):
     output = check_output(["pyodide", "--version"]).decode("utf-8")
-    assert "Pyodide CLI Version:" in output
-    assert "plugin-test Version: 1.0.0" in output
+    assert "pyodide CLI version:" in output
+    assert "plugin-test version: 1.0.0" in output
 
 
 def test_click_click_object_defintion():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.2", "setuptools_scm[toml]>=6.2"]
-
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
 
 [project]
 name = "pyodide-cli"
-version = "0.0.1"
+dynamic = ["version"]
 authors = [{name = "Pyodide developers"}]
 description = '"The command line interface for the Pyodide project"'
 classifiers = [
@@ -31,18 +30,11 @@ Documentation = "https://pyodide.org/en/stable/"
 [project.optional-dependencies]
 test = ["pytest"]
 
+[tool.hatch.version]
+source = "vcs"
+
 [project.scripts]
 pyodide = "pyodide_cli.__main__:main"
-
-[tool.setuptools]
-package-dir = {"" = "."}
-include-package-data = false
-
-[tool.setuptools.packages]
-find = {namespaces = false}
-
-# Evable versioning via setuptools_scm
-[tool.setuptools_scm]
 
 [tool.pycln]
 all = true


### PR DESCRIPTION
Updates `pyodide --version` command to show versions of registered plugins. Also changes the build backend from `setuptools` to `hatchling` as we did in other repos.

In addition to the pyodide CLI version, `pyodide --version` now shows the versions of packages that registers `pyodide.cli` entrypoint. It works by checking the distribution metadata provided by importlib.

```bash
$ pyodide --version
pyodide CLI version: 0.2.4.dev5+g0b96c05.d20240103
auditwheel_emscripten version: 0.0.14
pyodide-build version: 0.24.1
```

Related: https://github.com/pyodide/pyodide/issues/3745


