### PR TITLE
Remove typer extra requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.4] - 2024-06-23
+
+### Fixed
+
+- Fixed the warning "typer does not provide the extra 'all'" when installing the package.
+  ([#32](https://github.com/pyodide/pyodide-cli/pull/32))
+
 ## [0.2.3] - 2023-01-26
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "typer[standard]",
+    "typer",
     "rich",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "typer[all]",
+    "typer[standard]",
     "rich",
 ]
 


### PR DESCRIPTION
Typer doesn't accept `[all]` extra anymore, it just installs rich even without it.

Resolves: https://github.com/pyodide/pyodide/issues/4879