### PR TITLE
Fix `test_click_click_object_definition` on macOS, and use temporary paths for generating plugins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,11 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10.2
+          python-version: 3.12
       - name: Install
         shell: bash -l {0}
         run: |

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -1,4 +1,5 @@
 import pathlib
+import shutil
 import subprocess
 from multiprocessing import Process, Queue, set_start_method
 from subprocess import check_output
@@ -12,14 +13,18 @@ except RuntimeError:
 
 
 @pytest.fixture(scope="module")
-def plugins():
-    test_plugin = pathlib.Path(__file__).parent / "plugin-test"
+def plugins(tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("plugin-test")
+    source_plugin = pathlib.Path(__file__).parent / "plugin-test"
 
-    subprocess.run(["pip", "install", str(test_plugin)])
+    tmp_plugin = tmp_dir / "plugin-test"
+    shutil.copytree(source_plugin, tmp_plugin)
+
+    subprocess.run(["pip", "install", str(tmp_plugin)])
 
     yield
 
-    subprocess.run(["pip", "uninstall", "-y", test_plugin.name])
+    subprocess.run(["pip", "uninstall", "-y", "plugin-test"])
 
 
 def test_cli_help():

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -1,9 +1,14 @@
 import pathlib
 import subprocess
-from multiprocessing import Process, Queue
+from multiprocessing import Process, Queue, set_start_method
 from subprocess import check_output
 
 import pytest
+
+try:
+    set_start_method("fork")
+except RuntimeError:
+    pass
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
- macOS uses `spawn` as the start method by default, and nested functions can't be pickled
- use temporary paths with generated plugins
- add macOS for testing (this test failed and wasn't caught in CI)
- use Python 3.12 for testing – I'll bump the minimum required version to 3.12 in another PR after this