### PR TITLE
Support Python>=3.12, adopt SPDX licensing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.5.0
         with:
           python-version: 3.12
       - name: Install
@@ -30,15 +30,13 @@ jobs:
         run: |
           python -m pytest
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     environment: PyPi-deploy
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions/setup-python@v3
-        with:
-          python-version: 3.10.2
+      - uses: actions/setup-python@v5.5.0
       - name: Install requirements and build wheel
         shell: bash -l {0}
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: "3.10"
+  python: "3.12"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v5.0.0"
@@ -24,7 +24,7 @@ repos:
     rev: "v3.19.1"
     hooks:
       - id: pyupgrade
-        args: ["--py310-plus"]
+        args: ["--py312-plus"]
 
   - repo: https://github.com/hadialqattan/pycln
     rev: "v2.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ name = "pyodide-cli"
 dynamic = ["version"]
 authors = [{name = "Pyodide developers"}]
 description = '"The command line interface for the Pyodide project"'
+license = "MPL-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Operating System :: OS Independent",
 ]
 requires-python = ">= 3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Operating System :: OS Independent",
 ]
-requires-python = ">= 3.10"
+requires-python = ">= 3.12"
 dependencies = [
     "typer",
     "rich",


### PR DESCRIPTION
- use Python 3.12 wherever we can
- drop the license classifiers in favour of PEP 639's better licensing which deprecated PyPI's trove classifiers and recommends the SPDX license expression (MPL-2.0) in this case.