### PR TITLE
Prepare release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,12 @@
 name: main
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: main-${{ github.head_ref || github.run_id }}
@@ -11,39 +14,24 @@ concurrency:
 
 jobs:
   test:
+    permissions:
+      contents: read
     strategy:
       matrix:
         runs-on: [ubuntu-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-python@v5.5.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: 3.12
-      - name: Install
-        shell: bash -l {0}
-        run: |
-          python -m pip install -e ".[test]"
-      - name: Test
-        shell: bash -l {0}
-        run: |
-          python -m pytest
-  deploy:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    environment: PyPi-deploy
-    steps:
-      - uses: actions/checkout@v4.2.2
 
-      - uses: actions/setup-python@v5.5.0
-      - name: Install requirements and build wheel
-        shell: bash -l {0}
-        run: |
-          python -m pip install build twine
-          python -m build .
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Install
+        run: python -m pip install -e ".[test]"
+
+      - name: Test
+        run: python -m pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
+
+env:
+  FORCE_COLOR: 3
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: |
+          python -m pip install build
+          python -m build .
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyodide-cli
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted publishing
+      attestations: write
+      contents: read
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-path: "dist/*"
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # pyodide-cli
 
 [![PyPI Latest Release](https://img.shields.io/pypi/v/pyodide-cli.svg)](https://pypi.org/project/pyodide-cli/)
-![GHA](https://github.com/pyodide/pyodide-cli/actions/workflows/main.yml/badge.svg)
+![GHA-main](https://github.com/pyodide/pyodide-cli/actions/workflows/main.yml/badge.svg)
+![GHA-release](https://github.com/pyodide/pyodide-cli/actions/workflows/release.yml/badge.svg)
 [![codecov](https://codecov.io/gh/pyodide/pyodide-cli/branch/main/graph/badge.svg)](https://codecov.io/gh/pyodide/pyodide-cli)
 
 The command line interface for the Pyodide project.
 
 In most cases, you do not need to install this package directly, and it would be installed as
-a dependency of other packages in the ecosystem (e.g. pyodide-build).
+a dependency of other packages in the ecosystem (e.g., pyodide-build, pyodide-pack, auditwheel-emscripten, etc.)
 
 ## Installation
 

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -45,7 +45,8 @@ def callback(
     """A command line interface for Pyodide.
 
     Other CLI subcommands are registered via the plugin system by installing
-    Pyodide compatible packages (e.g. pyodide-build).
+    Pyodide ecosystem packages (e.g. pyodide-build, pyodide-pack,
+    auditwheel-emscripten, etc.)
     """
     pass
 


### PR DESCRIPTION
- Closes #38
- Closes #39
	- I don't have access to https://pypi.org/project/pyodide-cli/ on GitHub, tagging @ryanking13 and @hoodmane – could either of you please configure the trusted publishing? Thank you!
- We should tag v0.3.0 after this, as #30 was a feature