### PR TITLE
Replace Typer app with click cli

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,8 @@ repos:
           - types-setuptools
           - numpy
           - pytest
+          - click
+          - typer
 
   - repo: https://github.com/codespell-project/codespell
     rev: "v2.4.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2025-09-07
+
+### Changed
+
+- `pyodide-cli` will now use `click` app instead of `typer` app,
+  thus rich format help panel is no longer displayed for `pyodide-cli`.
+- The source of registered commands are now displayed in a slightly different style.
+  ([#47](https://github.com/pyodide/pyodide-cli/pull/47))
+
 ## [0.3.0] - 2025-04-05
 
 ### Added

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -1,7 +1,6 @@
 import sys
 from collections import defaultdict
 from functools import cache
-from gettext import gettext
 from importlib.metadata import Distribution, EntryPoint
 from importlib.metadata import distribution as importlib_distribution
 from importlib.metadata import entry_points
@@ -66,14 +65,16 @@ class OriginGroup(click.Group):
             last_source: str = ""
             rows: list[tuple[str, str]] = []
 
+            with formatter.section("Commands"):
+                pass
+
             def write_row():
                 if rows:
                     if len(last_source):
                         source_desc = f" Registered by {last_source}"
                     else:
                         source_desc = ""
-                    # NOTE: gettext is used in click! Any i18n support?
-                    with formatter.section(f"{gettext('Commands')}{source_desc}"):
+                    with formatter.section(f"{source_desc}"):
                         formatter.write_dl(rows)
                 rows.clear()
 

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -169,9 +169,7 @@ def register_plugins():
                 getattr(module, "__doc__", ""), origin_text
             )
 
-        if isinstance(module, click.Group):
-            cli.add_command(module, name=plugin_name, origin=pkgname)
-        elif callable(module):
+        if callable(module):
             typer_kwargs = getattr(module, "typer_kwargs", None)
             # construct Typer app and preserve typer_kwargs as of now
             if typer_kwargs is not None:

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -26,16 +26,15 @@ class OriginGroup(click.Group):
         """
         Register click commands with its origin.
         """
-        # if name is not provided, command name is used
-        if name is None:
-            name = cmd.name
-        if name is None:
-            name = ""  # FIXME: not the bes gt way?
+        super().add_command(cmd, name)
+
+        # if name is None, click will raise an exception
+        name = str(name or cmd.name)
+
         if origin is None:
             origin = ""
 
         self.origin_map[name] = origin
-        super().add_command(cmd, name)
 
     @override
     def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter):

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -1,11 +1,11 @@
-from collections import defaultdict
-from gettext import gettext
-from typing import override
 import sys
+from collections import defaultdict
 from functools import cache
+from gettext import gettext
 from importlib.metadata import Distribution, EntryPoint
 from importlib.metadata import distribution as importlib_distribution
 from importlib.metadata import entry_points
+from typing import override
 
 import click  # type: ignore[import]
 import typer  # type: ignore[import]

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -158,7 +158,7 @@ def register_plugins():
 
     for plugin_name, (module, ep) in plugins.items():
         pkgname = _entrypoint_to_pkgname(ep)
-        origin_text = f"Registered by: {pkgname}"
+        origin_text = f"Registered by {pkgname}:"
 
         if isinstance(module, typer.Typer):
             typer_info = TyperInfo(module)

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -69,7 +69,7 @@ class OriginGroup(click.Group):
             def write_row():
                 if rows:
                     if len(last_source):
-                        source_desc = f" Registered by: {last_source}"
+                        source_desc = f" Registered by {last_source}"
                     else:
                         source_desc = ""
                     # NOTE: gettext is used in click! Any i18n support?

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -7,9 +7,10 @@ from importlib.metadata import distribution as importlib_distribution
 from importlib.metadata import entry_points
 from typing import override
 
-import click  # type: ignore[import]
-import typer  # type: ignore[import]
-from typer.main import TyperInfo, solve_typer_info_help  # type: ignore[import]
+import click
+import typer
+from typer.main import solve_typer_info_help
+from typer.models import TyperInfo
 
 from . import __version__
 

--- a/pyodide_cli/tests/plugin-test/plugin_test/cli.py
+++ b/pyodide_cli/tests/plugin-test/plugin_test/cli.py
@@ -1,0 +1,25 @@
+import click  # type: ignore[import]
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """
+    Test help message short desc
+
+    Test help message long desc
+    """
+    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@cli.command()
+@click.argument("name", required=True)
+def hello(name: str) -> None:
+    """
+    Test help message short desc
+
+    Test help message long desc
+    """
+    click.echo(f"Hello {name}")

--- a/pyodide_cli/tests/plugin-test/pyproject.toml
+++ b/pyodide_cli/tests/plugin-test/pyproject.toml
@@ -10,3 +10,4 @@ authors = []
 [project.entry-points."pyodide.cli"]
 plugin_test_func = "plugin_test.main:main"
 plugin_test_app = "plugin_test.app:app"
+plugin_test_cli = "plugin_test.cli:cli"

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -67,12 +67,14 @@ def test_click_click_object_defintion():
 
 def test_plugin_origin(plugins):
     output = check_output(["pyodide", "--help"]).decode("utf-8")
-    msg = "Registered by: plugin-test"
+    msg = "Registered by plugin-test:"
 
     assert msg in output
 
 
-@pytest.mark.parametrize("entrypoint", ["plugin_test_app", "plugin_test_func"])
+@pytest.mark.parametrize(
+    "entrypoint", ["plugin_test_app", "plugin_test_func", "plugin_test_cli"]
+)
 def test_plugin_origin_subcommand(plugins, entrypoint):
     output = check_output(["pyodide", entrypoint, "--help"]).decode("utf-8")
     msg = "Registered by: plugin-test"

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -77,6 +77,6 @@ def test_plugin_origin(plugins):
 )
 def test_plugin_origin_subcommand(plugins, entrypoint):
     output = check_output(["pyodide", entrypoint, "--help"]).decode("utf-8")
-    msg = "Registered by: plugin-test"
+    msg = "Registered by plugin-test:"
 
     assert msg in output


### PR DESCRIPTION
Replace main typer app of pyodide-cli with click group.

As pytest depends on Typer's rich help integration which yields the origin of the subcommand,
it was implemented by subclassing `click.Group`. The following is an excerpt from pytest.

```
pyodide_cli/tests/test_cli.py::test_plugin_origin Usage: pyodide [OPTIONS] COMMAND [ARGS]...

  A command line interface for Pyodide.

  Other CLI subcommands are registered via the plugin system by installing
  Pyodide ecosystem packages (e.g. pyodide-build, pyodide-pack, auditwheel-
  emscripten, etc.)

Options:
  --version  Show the version of the Pyodide CLI
  --help     Show this message and exit.

Commands Registered by plugin-test:
  plugin_test_app   Test help message short desc
  plugin_test_cli   Test help message short desc
  plugin_test_func  Test help message short desc
```

Technically `typer_kwargs` is still supported. Perhaps we may need to introduce `click_kwargs` later on as a substitute.

I expect the overall behavior to be compatible, barring subtle difference due to different default behavior of click and typer.

Related: https://github.com/pyodide/pyodide-build/issues/204
