### PR TITLE
Accept click.command objects as command

### DIFF
--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -170,7 +170,7 @@ def register_plugins():
                 getattr(module, "__doc__", ""), origin_text
             )
 
-        if isinstance(module, click.Group):
+        if isinstance(module, click.Command):
             cmd = module
         elif isinstance(module, typer.Typer):
             cmd = typer.main.get_command(module)


### PR DESCRIPTION
`isinstance(x, click.Group)` was evaluated to `False` when click.Command objects were given,
raising type error during conversion of some pyodide-build commands.