### PR TITLE
Remove redundant origin help message from subcommand

### DIFF
--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -8,8 +8,6 @@ from typing import override
 
 import click
 import typer
-from typer.main import solve_typer_info_help
-from typer.models import TyperInfo
 
 from . import __version__
 

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -70,4 +70,3 @@ def test_plugin_origin(plugins):
     msg = "Registered by plugin-test:"
 
     assert msg in output
-

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -71,12 +71,3 @@ def test_plugin_origin(plugins):
 
     assert msg in output
 
-
-@pytest.mark.parametrize(
-    "entrypoint", ["plugin_test_app", "plugin_test_func", "plugin_test_cli"]
-)
-def test_plugin_origin_subcommand(plugins, entrypoint):
-    output = check_output(["pyodide", entrypoint, "--help"]).decode("utf-8")
-    msg = "Registered by plugin-test:"
-
-    assert msg in output


### PR DESCRIPTION
As suggested by @agriyakhetarpal (https://github.com/pyodide/pyodide-build/pull/287#pullrequestreview-3697454275).

Remove `Registered by pyodide-build:` from the subcommand help message.