### PR TITLE
Make typer optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-01-27
+
+### Changed
+
+- `typer` is now optional dependency, and will not be installed by default.
+  Packages using `typer` should now explicitly install `typer` as a dependency.
+  ([#55](https://github.com/pyodide/pyodide-cli/pull/55))
+
 ## [0.4.0] - 2025-09-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ You can register a subcommand in the `pyodide` CLI in your own package by:
    do_something = "<your-package>.cli:main"
    ```
 
-   where in this example `main` needs to be a function with type annotations
-   that can be converted to a CLI with [typer](https://typer.tiangolo.com/).
+   where in this example `main` needs to be either:
+   - A [click](https://click.palletsprojects.com/) command/group (recommended)
+   - A [typer](https://typer.tiangolo.com/) app or function (requires `typer` to be installed)
 
 
 ## License

--- a/pyodide_cli/app.py
+++ b/pyodide_cli/app.py
@@ -4,12 +4,21 @@ from functools import cache
 from importlib.metadata import Distribution, EntryPoint
 from importlib.metadata import distribution as importlib_distribution
 from importlib.metadata import entry_points
-from typing import override
+from typing import TYPE_CHECKING, override
 
 import click
-import typer
 
 from . import __version__
+
+if TYPE_CHECKING:
+    import typer
+
+try:
+    import typer  # noqa: F811
+
+    TYPER_AVAILABLE = True
+except ImportError:
+    TYPER_AVAILABLE = False
 
 
 class OriginGroup(click.Group):
@@ -154,9 +163,9 @@ def register_plugins():
         pkgname = _entrypoint_to_pkgname(ep)
         if isinstance(module, click.Command):
             cmd = module
-        elif isinstance(module, typer.Typer):
+        elif TYPER_AVAILABLE and isinstance(module, typer.Typer):
             cmd = typer.main.get_command(module)
-        elif callable(module):
+        elif TYPER_AVAILABLE and callable(module):
             typer_kwargs = getattr(module, "typer_kwargs", {})
             app = typer.Typer()
             app.command(
@@ -176,9 +185,9 @@ def main():
 
 
 if "sphinx" in sys.modules and __name__ != "__main__":
-    # Create the typer click object to generate docs with sphinx-click
+    # Create the click object to generate docs with sphinx-click
     register_plugins()
-    typer_click_object = cli
+    click_object = cli
 
 if __name__ == "__main__":
     main()

--- a/pyodide_cli/tests/test_cli.py
+++ b/pyodide_cli/tests/test_cli.py
@@ -39,8 +39,6 @@ def test_cli_version(plugins):
 
 
 def test_click_click_object_defintion():
-    # By default the typer-click-object is not defined
-    # Run in a separate process to make s
     q = Queue()
 
     def func(q: Queue, with_sphinx=False):
@@ -56,13 +54,13 @@ def test_click_click_object_defintion():
     p.start()
     p.join()
     app_dir = q.get()
-    assert "typer_click_object" not in app_dir
+    assert "click_object" not in app_dir
 
     p = Process(target=func, args=(q,), kwargs={"with_sphinx": True})
     p.start()
     p.join()
     app_dir = q.get()
-    assert "typer_click_object" in app_dir
+    assert "click_object" in app_dir
 
 
 def test_plugin_origin(plugins):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 requires-python = ">= 3.12"
 dependencies = [
-    "typer",
+    "click",
     "rich",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ Homepage = "https://github.com/pyodide/pyodide"
 Documentation = "https://pyodide.org/en/stable/"
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = [
+    "pytest",
+    "typer",
+]
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
Close: https://github.com/pyodide/pyodide-build/issues/204

Makes typer optional. Packages using typer will still work and be registered by pyodide-cli, but typer is not installed with pyodide-cli by default.

- [x] changelog